### PR TITLE
Optimized robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,8 +3,6 @@ User-agent: *
 Disallow: /projects/dndice/diceroller.js
 Disallow: /website-template.txt
 Disallow: /404.html
-Disallow: /assets/img/74072833.png
-Disallow: /assets/img/duvalstudioslogo.png
-Disallow: /assets/img/logo-ico.ico
-Disallow: /assets/img/logo-png.png
-Disallow: /assets/img/logo-text.png
+Disallow: /assets/img/
+# If you want to disallow all of your images from being crawled, you can just mention 
+# a folder like this instead of all of your individual file paths.


### PR DESCRIPTION
If you want to disallow crawlers from crawling all of your images, you can just mention a folder instead of each specific file path. So 
``` 
Disallow: /assets/img/file1.png
Disallow: /assets/img/file2.png
Disallow: /assets/img/file3.png
Disallow: /assets/img/file4.png
Disallow: /assets/img/file5.png
```
can easily be just
``` 
Disallow: /assets/img/
```
I edited the file to institute this
